### PR TITLE
enhancments in dashboards (decimals, line interpolation)

### DIFF
--- a/grafana/dashboards/vwsfriend/Internal/charge_session.json
+++ b/grafana/dashboards/vwsfriend/Internal/charge_session.json
@@ -34,7 +34,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "iteration": 1656077962186,
   "links": [
     {
       "asDropdown": false,
@@ -102,7 +101,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "stepAfter",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -329,7 +328,7 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "9.0.4",
       "targets": [
         {
           "datasource": {
@@ -585,6 +584,10 @@
               {
                 "id": "unit",
                 "value": "kwatt"
+              },
+              {
+                "id": "decimals",
+                "value": 1
               }
             ]
           },
@@ -609,6 +612,10 @@
               {
                 "id": "unit",
                 "value": "kwatt"
+              },
+              {
+                "id": "decimals",
+                "value": 1
               }
             ]
           },
@@ -633,6 +640,10 @@
               {
                 "id": "unit",
                 "value": "kwatth"
+              },
+              {
+                "id": "decimals",
+                "value": 1
               }
             ]
           },
@@ -686,7 +697,7 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "9.0.4",
       "targets": [
         {
           "datasource": {
@@ -956,7 +967,7 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "9.0.4",
       "targets": [
         {
           "datasource": {
@@ -1166,7 +1177,7 @@
           "zoom": 18
         }
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "9.0.4",
       "targets": [
         {
           "datasource": {
@@ -1259,7 +1270,7 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "9.0.4",
       "targets": [
         {
           "datasource": {

--- a/grafana/dashboards/vwsfriend/Internal/trip_details.json
+++ b/grafana/dashboards/vwsfriend/Internal/trip_details.json
@@ -24,7 +24,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "iteration": 1654775432637,
   "links": [
     {
       "asDropdown": false,
@@ -90,7 +89,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "stepAfter",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -359,7 +358,7 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "8.5.5",
+      "pluginVersion": "9.0.4",
       "targets": [
         {
           "datasource": {
@@ -556,7 +555,7 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "8.5.5",
+      "pluginVersion": "9.0.4",
       "targets": [
         {
           "datasource": {
@@ -656,7 +655,7 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "8.5.5",
+      "pluginVersion": "9.0.4",
       "targets": [
         {
           "datasource": {

--- a/grafana/dashboards/vwsfriend/VWsFriend/charges.json
+++ b/grafana/dashboards/vwsfriend/VWsFriend/charges.json
@@ -25,7 +25,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "iteration": 1658692777221,
   "links": [
     {
       "asDropdown": false,
@@ -237,6 +236,10 @@
               {
                 "id": "custom.width",
                 "value": 75
+              },
+              {
+                "id": "custom.align",
+                "value": "left"
               }
             ]
           },
@@ -269,6 +272,10 @@
               {
                 "id": "custom.filterable",
                 "value": true
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
               }
             ]
           },
@@ -300,7 +307,7 @@
               },
               {
                 "id": "decimals",
-                "value": 2
+                "value": 1
               }
             ]
           },
@@ -436,7 +443,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "9.0.2",
+      "pluginVersion": "9.0.4",
       "targets": [
         {
           "datasource": {
@@ -555,7 +562,7 @@
         "frameIndex": 1,
         "showHeader": true
       },
-      "pluginVersion": "9.0.2",
+      "pluginVersion": "9.0.4",
       "targets": [
         {
           "datasource": {
@@ -673,7 +680,7 @@
         },
         "showHeader": true
       },
-      "pluginVersion": "9.0.2",
+      "pluginVersion": "9.0.4",
       "targets": [
         {
           "datasource": {


### PR DESCRIPTION
- Changed decimal to 1 in charge session and charge dashboard as in #284 discussed
- the duration column in the charges table is to small, so days in the total cell are not displayed. I changed to left aligned but maybe bigger width would be good.
- for panels with variable time range which then can include times with offline state, linear line interpolation looked wired and step after was best. For fixed time range like in charge session or trip details linear or smooth is fine too and maybe looks a bit better
(iteration property is removed in new grafana version)