### PR TITLE
Handle null remaining charge times

### DIFF
--- a/grafana/dashboards/vwsfriend/VWsFriend/overview.json
+++ b/grafana/dashboards/vwsfriend/VWsFriend/overview.json
@@ -1532,7 +1532,7 @@
           "query": "",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "(SELECT\n  to_timestamp(0) AS \"time\",\n  MAX(\"remainingChargingTimeToComplete_min\")\nFROM charges\nWHERE\n  vehicle_vin = '$VIN')\nUNION\n(SELECT\n  \"carCapturedTimestamp\" AS \"time\",\n  \"remainingChargingTimeToComplete_min\"\nFROM charges\nWHERE\n  vehicle_vin = '$VIN'\nORDER BY \"time\" DESC\nLIMIT 1)",
+          "rawSql": "(SELECT\n  to_timestamp(0) AS \"time\",\n  MAX(\"remainingChargingTimeToComplete_min\")\nFROM charges\nWHERE\n  vehicle_vin = '$VIN')\nUNION\n(SELECT\n  \"carCapturedTimestamp\" AS \"time\",\n  coalesce(\"remainingChargingTimeToComplete_min\",0)\nFROM charges\nWHERE\n  vehicle_vin = '$VIN'\nORDER BY \"time\" DESC\nLIMIT 1)",
           "refId": "A",
           "resultFormat": "time_series",
           "select": [


### PR DESCRIPTION
remainingChargingTimeToComplete is now null when the charge has finished or in error state causing an incorrect value to display on the dashboard.  Previously this value was zero when the charge was in these states.