### PR TITLE
Fix: Correct sort order for battery temperature in Car Overview Dashb…

### DIFF
--- a/grafana/dashboards/vwsfriend/VWsFriend/overview.json
+++ b/grafana/dashboards/vwsfriend/VWsFriend/overview.json
@@ -2373,7 +2373,7 @@
           "format": "table",
           "hide": false,
           "rawQuery": true,
-          "rawSql": "SELECT\n    \"carCapturedTimestamp\" AS \"time\",\n    (((\"temperatureHvBatteryMin_K\" + \"temperatureHvBatteryMax_K\")/2) - 273.15) AS \"Battery Temperature\"\nFROM\n    battery_temperature\nWHERE\n    $__timeFilter(\"carCapturedTimestamp\") AND\n    vehicle_vin = '$VIN'\nORDER BY\n    \"carCapturedTimestamp\" DESC",
+          "rawSql": "SELECT\n    \"carCapturedTimestamp\" AS \"time\",\n    (((\"temperatureHvBatteryMin_K\" + \"temperatureHvBatteryMax_K\")/2) - 273.15) AS \"Battery Temperature\"\nFROM\n    battery_temperature\nWHERE\n    $__timeFilter(\"carCapturedTimestamp\") AND\n    vehicle_vin = '$VIN'\nORDER BY\n    \"carCapturedTimestamp\" ASC",
           "refId": "B",
           "sql": {
             "columns": [


### PR DESCRIPTION
The battery temperature in the "Charging" panel of the Car Overview Dashboard was being displayed incorrectly due to an incorrect sort order in the underlying SQL query.

This commit changes the sort order from DESC to ASC, ensuring that the last recorded temperature is displayed correctly.